### PR TITLE
Add observability: PATH hint, startup inventory, check command, macOS docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,39 @@ curl -fsSL https://raw.githubusercontent.com/calebfaruki/airlock/main/install.sh
 
 This downloads the daemon, installs it to `~/.local/bin/`, and runs `airlock init` to set up the system service.
 
+### macOS: Homebrew PATH
+
+On macOS, `launchd` runs the daemon with a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) that does not include Homebrew's `/opt/homebrew/bin`. If your CLI tools are installed via Homebrew, the daemon won't find them.
+
+Two options:
+
+**Option A: Absolute paths in command modules** (recommended — explicit and auditable)
+
+Eject the built-in and set `bin` to the full path:
+
+```sh
+airlock-daemon eject git
+# Edit ~/.config/airlock/commands/git.toml
+# Change: bin = "git"
+# To:     bin = "/opt/homebrew/bin/git"
+```
+
+Run `which <command>` to find the path. Repeat for each Homebrew-installed tool.
+
+**Option B: Add Homebrew to the launchd PATH**
+
+Edit `~/Library/LaunchAgents/dev.airlock.daemon.plist` and add an `EnvironmentVariables` key:
+
+```xml
+<key>EnvironmentVariables</key>
+<dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+</dict>
+```
+
+Then reload: `launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/dev.airlock.daemon.plist && launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.airlock.daemon.plist`
+
 ### Container Setup
 
 Download the shim from [releases](https://github.com/calebfaruki/airlock/releases) and add to your Dockerfile:

--- a/crates/airlock-daemon/src/commands/registry.rs
+++ b/crates/airlock-daemon/src/commands/registry.rs
@@ -113,4 +113,16 @@ impl CommandRegistry {
     pub fn has_user_override(&self, command: &str) -> bool {
         self.user_sources.contains_key(command)
     }
+
+    pub fn command_names(&self) -> Vec<&str> {
+        let mut names: Vec<&str> = self.modules.keys().map(|s| s.as_str()).collect();
+        names.sort();
+        names
+    }
+
+    pub fn user_override_names(&self) -> Vec<&str> {
+        let mut names: Vec<&str> = self.user_sources.keys().map(|s| s.as_str()).collect();
+        names.sort();
+        names
+    }
 }

--- a/crates/airlock-daemon/src/lib.rs
+++ b/crates/airlock-daemon/src/lib.rs
@@ -422,7 +422,16 @@ pub async fn handle_connection(
     let mut child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) => {
-            let msg = format!("failed to execute {}: {e}", module.command.bin);
+            let msg = if e.kind() == std::io::ErrorKind::NotFound
+                && !module.command.bin.contains('/')
+            {
+                format!(
+                    "failed to execute {}: {e} (hint: use an absolute path in the command module, e.g. bin = \"/opt/homebrew/bin/{}\")",
+                    module.command.bin, module.command.bin
+                )
+            } else {
+                format!("failed to execute {}: {e}", module.command.bin)
+            };
             let err = build_error_response(id, -32603, msg.clone());
             writer
                 .write_all(&send_line(&serde_json::to_string(&err)?))

--- a/crates/airlock-daemon/src/main.rs
+++ b/crates/airlock-daemon/src/main.rs
@@ -200,8 +200,53 @@ async fn main() {
             }
             return;
         }
+        "check" => {
+            let mut registry = CommandRegistry::new();
+            registry.load_builtins();
+
+            let user_dir = user_commands_dir();
+            let mut has_errors = false;
+
+            if user_dir.exists() {
+                if let Ok(entries) = std::fs::read_dir(&user_dir) {
+                    for entry in entries.flatten() {
+                        let path = entry.path();
+                        if path.extension().and_then(|e| e.to_str()) != Some("toml") {
+                            continue;
+                        }
+                        let name = path.file_stem().unwrap().to_string_lossy();
+                        let content = match std::fs::read_to_string(&path) {
+                            Ok(c) => c,
+                            Err(e) => {
+                                eprintln!("  error: {name} — {e}");
+                                has_errors = true;
+                                continue;
+                            }
+                        };
+                        match airlock_daemon::commands::CommandModule::parse(&content) {
+                            Ok(_) => eprintln!("  ok: {name}"),
+                            Err(e) => {
+                                eprintln!("  error: {name} — {e}");
+                                has_errors = true;
+                            }
+                        }
+                    }
+                }
+            }
+
+            let commands = registry.command_names();
+            eprintln!("airlock: {} built-in commands", commands.len());
+
+            if has_errors {
+                eprintln!("airlock: validation failed");
+                std::process::exit(1);
+            } else {
+                eprintln!("airlock: all modules valid");
+            }
+            return;
+        }
         _ => {
-            eprintln!("usage: airlock-daemon <start|version|init|show|diff|eject>");
+            eprintln!("usage: airlock-daemon <start|version|init|check|show|diff|eject>");
             std::process::exit(1);
         }
     }
@@ -239,7 +284,16 @@ async fn main() {
     ));
 
     let mount_cache: MountCache = Arc::new(RwLock::new(HashMap::new()));
-    let registry = Arc::new(load_registry());
+    let registry = load_registry();
+    eprintln!(
+        "airlock: loaded commands: {}",
+        registry.command_names().join(", ")
+    );
+    let overrides = registry.user_override_names();
+    if !overrides.is_empty() {
+        eprintln!("airlock: user overrides: {}", overrides.join(", "));
+    }
+    let registry = Arc::new(registry);
     let cmd_locks: ConcurrencyLocks = Arc::new(RwLock::new(HashMap::new()));
     let hook_runner = Arc::new(HookRunner::new(hooks_dir()));
 


### PR DESCRIPTION
Spawn errors for non-absolute bin paths now hint at using absolute paths (common launchd PATH issue on macOS). Daemon prints loaded commands on startup. New 'check' subcommand validates all TOML modules without starting the daemon. README documents macOS Homebrew PATH workarounds.