### PR TITLE
Harden macOS daemon PATH, git deny list, and Docker Desktop docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,18 +62,18 @@ docker run \
     your-image
 ```
 
-On macOS, use `~/.config/airlock/docker-airlock.sock` as the host path.
+### Docker Desktop (macOS)
 
-### macOS Note
+Docker Desktop runs containers inside a Linux VM via VirtioFS, which remaps bind-mounted socket permissions to `root:root 0660`. Non-root container users need the root group added:
 
-The launchd service inherits a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`). Tools installed via Homebrew, nix, or cargo won't be found by default. Use absolute paths in command modules:
-
-```toml
-[command]
-bin = "/opt/homebrew/bin/gh"
+```sh
+docker run \
+    --group-add 0 \
+    -v ~/.config/airlock/docker-airlock.sock:/run/docker-airlock.sock \
+    your-image
 ```
 
-Run `airlock-daemon check` to validate all modules before restarting the daemon.
+On Linux, Docker runs natively and `--group-add 0` is not needed.
 
 ## Usage
 
@@ -138,8 +138,6 @@ On startup, the daemon prints loaded commands and any user overrides to stderr:
 airlock: loaded commands: aws, docker, gh, git, ssh, terraform
 airlock: user overrides: gh
 ```
-
-If a command fails because the binary isn't found, the error message hints at using an absolute path — the most common issue on macOS where launchd has a minimal PATH.
 
 Run `airlock-daemon check` before restarting to catch TOML syntax errors and missing binaries early.
 

--- a/crates/airlock-daemon/src/commands/builtins/git/SECURITY.md
+++ b/crates/airlock-daemon/src/commands/builtins/git/SECURITY.md
@@ -12,6 +12,14 @@
 | `-c` | Short form of `--config` |
 | `--exec-path` | Redirects git to load sub-programs from attacker-controlled directory |
 | `--template` | Copies hooks from a local directory into cloned repo — hooks execute on clone |
+| `--config-env` | Injects git config from environment variables — bypasses `-c` deny |
+| `--receive-pack` | Overrides receive-pack binary path — arbitrary command execution on push |
+| `credential` | Subcommand that extracts host credentials via `credential fill/approve/reject` |
+| `daemon` | Starts a git daemon — arbitrary network access from the host |
+| `shell` | Restricted login shell — not needed in proxy context, potential escape vector |
+| `upload-pack` | Transport plumbing — direct pack access bypassing normal fetch flow |
+| `receive-pack` | Transport plumbing — direct pack access bypassing normal push flow |
+| `upload-archive` | Transport plumbing — archive generation over transport protocol |
 
 ## Stripped Env Vars
 

--- a/crates/airlock-daemon/src/commands/builtins/git/module.toml
+++ b/crates/airlock-daemon/src/commands/builtins/git/module.toml
@@ -2,7 +2,25 @@
 bin = "git"
 
 [deny]
-args = ["--upload-pack", "-u", "--config", "-c", "--exec-path", "--template"]
+args = [
+    # Flags — override git internals or inject config
+    "--upload-pack",
+    "-u",
+    "--config",
+    "-c",
+    "--exec-path",
+    "--template",
+    "--config-env",
+    "--receive-pack",
+
+    # Subcommands — dangerous plumbing and credential access
+    "credential",
+    "daemon",
+    "shell",
+    "upload-pack",
+    "receive-pack",
+    "upload-archive",
+]
 
 [env]
 strip = ["GIT_SSH_COMMAND", "GIT_CONFIG", "GIT_CONFIG_GLOBAL", "GIT_CONFIG_PARAMETERS", "GIT_ATTR_SOURCE", "GIT_CONFIG_COUNT"]

--- a/crates/airlock-daemon/src/init.rs
+++ b/crates/airlock-daemon/src/init.rs
@@ -235,6 +235,11 @@ pub fn generate_launchd_plist(bin_path: &Path, data_dir: &Path) -> String {
         <key>SuccessfulExit</key>
         <false/>
     </dict>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
     <key>StandardOutPath</key>
     <string>{}/airlock-stdout.log</string>
     <key>StandardErrorPath</key>
@@ -401,6 +406,8 @@ mod tests {
         assert!(content.contains("<key>RunAtLoad</key>"));
         assert!(content.contains("<key>KeepAlive</key>"));
         assert!(content.contains("<key>SuccessfulExit</key>"));
+        assert!(content.contains("<key>EnvironmentVariables</key>"));
+        assert!(content.contains("/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"));
         assert!(content.contains("/Users/test/.local/share/airlock/airlock-stdout.log"));
     }
 

--- a/crates/airlock-daemon/src/lib.rs
+++ b/crates/airlock-daemon/src/lib.rs
@@ -185,16 +185,23 @@ async fn resolve_host_cwd(
         }
     }
 
-    let output = Command::new("docker")
+    let output = match Command::new("docker")
         .arg("inspect")
         .arg("--format")
         .arg("{{json .Mounts}}")
         .arg(container_id)
         .output()
         .await
-        .ok()?;
+    {
+        Ok(output) => output,
+        Err(_) => {
+            eprintln!("airlock: docker not found — the daemon's PATH may not include docker's install location");
+            return None;
+        }
+    };
 
     if !output.status.success() {
+        eprintln!("airlock: docker inspect failed for container {container_id} — is docker in the daemon's PATH?");
         return None;
     }
 
@@ -371,7 +378,7 @@ pub async fn handle_connection(
         (Some(cid), Some(cwd)) => match resolve_host_cwd(cid, cwd, &mount_cache).await {
             Some(path) => path,
             None => {
-                let reason = format!("cwd translation failed: could not inspect container {cid}");
+                let reason = format!("cwd translation failed: docker inspect failed for container {cid} — is docker in the daemon's PATH?");
                 let err = build_error_response(id, -32603, reason.clone());
                 writer
                     .write_all(&send_line(&serde_json::to_string(&err)?))


### PR DESCRIPTION
Add EnvironmentVariables with PATH to the launchd plist so the daemon can find docker and Homebrew-installed tools without absolute paths. Improve docker inspect error messages to hint at PATH issues.

Expand the git deny list with dangerous subcommands (credential, daemon, shell, upload-pack, receive-pack, upload-archive) and additional flags (--config-env, --receive-pack). Document threat rationale in SECURITY.md.

Add Docker Desktop section to README covering VirtioFS socket permission workaround (--group-add 0). Remove now-unnecessary macOS PATH warning.