### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "airlock-daemon"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "airlock-shim"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/crates/airlock-daemon/Cargo.toml
+++ b/crates/airlock-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "airlock-daemon"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/airlock-shim/Cargo.toml
+++ b/crates/airlock-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "airlock-shim"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Bump `airlock-daemon` and `airlock-shim` crate versions from 0.1.0 to 0.2.0

Prepares for the first signed release. After merge, tag `v0.2.0` and push to trigger the release workflow.